### PR TITLE
feat: Enforce Kubernetes-only LMEval backend

### DIFF
--- a/llama_stack/providers/remote/eval/lmeval/config.py
+++ b/llama_stack/providers/remote/eval/lmeval/config.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
 from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
 from llama_stack.apis.eval import BenchmarkConfig, EvalCandidate
+from llama_stack.providers.remote.eval.lmeval.errors import LMEvalConfigError
 from llama_stack.schema_utils import json_schema_type
-
-
 
 
 @json_schema_type
 @dataclass
 class LMEvalBenchmarkConfig(BenchmarkConfig):
     """Configuration for LMEval benchmark that extends the base BenchmarkConfig"""
-    
+
     # K8s specific configuration
     model: str
     eval_candidate: EvalCandidate
@@ -21,18 +20,16 @@ class LMEvalBenchmarkConfig(BenchmarkConfig):
     def __post_init__(self):
         """Validate configuration"""
         super().__post_init__()
-        
+
         if not self.model:
             raise ValueError("model must be provided")
-    
+
     def to_k8s_cr(self) -> Dict[str, Any]:
         """Convert configuration to Kubernetes CR format"""
         cr = {
             "apiVersion": "trustyai.opendatahub.io/v1alpha1",
             "kind": "LMEvalJob",
-            "metadata": {
-                "name": f"evaljob-{self.model.lower()}-1"
-            },
+            "metadata": {"name": f"evaljob-{self.model.lower()}-1"},
             "spec": {
                 "model": self.model,
                 "modelArgs": "",
@@ -41,26 +38,26 @@ class LMEvalBenchmarkConfig(BenchmarkConfig):
                 "pod": {"container": {"env": ""}},
             },
         }
-        
+
         return cr
-    
+
     @classmethod
     def from_k8s_cr(cls, cr: Dict[str, Any]) -> "LMEvalBenchmarkConfig":
         """Create configuration from Kubernetes CR"""
         spec = cr.get("spec", {})
-        
+
         # Extract values from CR
         model = spec.get("model", "hf")
         model_args = spec.get("modelArgs", [])
         task_list = spec.get("taskList", {"taskNames": ["unfair_tos"]})
         log_samples = spec.get("logSamples", True)
         namespace = cr.get("metadata", {}).get("namespace", "default")
-        
+
         # Extract environment variables
         env_vars = []
         if "pod" in spec and "container" in spec["pod"]:
             env_vars = spec["pod"]["container"].get("env", [])
-        
+
         # Create config with K8s parameters
         return cls(
             model=model,
@@ -72,7 +69,8 @@ class LMEvalBenchmarkConfig(BenchmarkConfig):
             # Add required BenchmarkConfig fields here
             eval_candidate=None,
             scoring_params={},
-        ) 
+        )
+
 
 @json_schema_type
 @dataclass
@@ -99,18 +97,16 @@ class K8sLMEvalConfig:
 @dataclass
 class LMEvalEvalProviderConfig:
     """Configuration for the LMEval Provider"""
-    
-    # Only include the use_k8s flag
-    use_k8s: bool = False
+
+    use_k8s: bool = True
     base_url: str = "/v1/completions"
+
     def __post_init__(self):
         """Validate configuration"""
         if not isinstance(self.use_k8s, bool):
-            raise ValueError("use_k8s must be a boolean")
+            raise LMEvalConfigError("use_k8s must be a boolean")
+        if self.use_k8s is False:
+            raise LMEvalConfigError("Only Kubernetes LMEval backend is supported at the moment")
 
 
-__all__ = [
-    "LMEvalBenchmarkConfig",
-    "K8sLMEvalConfig",
-    "LMEvalEvalProviderConfig"
-]
+__all__ = ["LMEvalBenchmarkConfig", "K8sLMEvalConfig", "LMEvalEvalProviderConfig"]

--- a/llama_stack/providers/remote/eval/lmeval/errors.py
+++ b/llama_stack/providers/remote/eval/lmeval/errors.py
@@ -1,0 +1,17 @@
+# Custom exceptions
+class LMEvalError(Exception):
+    """Base exception for LMEval errors"""
+
+    pass
+
+
+class LMEvalConfigError(LMEvalError):
+    """Configuration related errors"""
+
+    pass
+
+
+class LMEvalValidationError(LMEvalError):
+    """Validation related errors"""
+
+    pass

--- a/tests/lmeval/test_lmeval.py
+++ b/tests/lmeval/test_lmeval.py
@@ -1,0 +1,120 @@
+from unittest.mock import patch
+
+import pytest
+
+from llama_stack.apis.eval import BenchmarkConfig, ModelCandidate
+from llama_stack.apis.inference import SamplingParams
+from llama_stack.providers.remote.eval.lmeval.config import LMEvalEvalProviderConfig
+from llama_stack.providers.remote.eval.lmeval.errors import LMEvalConfigError
+from llama_stack.providers.remote.eval.lmeval.job import LMEval
+
+
+class TestLMEvalEvalProviderConfig:
+    def test_use_k8s_default(self):
+        """Test that use_k8s defaults to False"""
+        config = LMEvalEvalProviderConfig()
+        assert config.use_k8s is True
+
+    def test_use_k8s_true(self):
+        """Test that use_k8s can be set to True"""
+        config = LMEvalEvalProviderConfig(use_k8s=True)
+        assert config.use_k8s is True
+
+    def test_use_k8s_validation(self):
+        """Test that use_k8s must be a boolean"""
+        with pytest.raises(LMEvalConfigError, match="use_k8s must be a boolean"):
+            LMEvalEvalProviderConfig(use_k8s="True")
+
+    def test_use_k8s_required(self):
+        """Test that use_k8s must be True for now"""
+        with pytest.raises(LMEvalConfigError, match="Only Kubernetes LMEval backend is supported at the moment"):
+            config = LMEvalEvalProviderConfig(use_k8s=False)
+            config.__post_init__()
+
+
+class TestLMEvalJob:
+    @pytest.fixture
+    def lmeval_instance(self):
+        """Create a basic LMEval instance for testing"""
+        config = LMEvalEvalProviderConfig(use_k8s=True)
+        instance = LMEval(config=config)
+        instance.use_k8s = True
+        return instance
+
+    @pytest.mark.asyncio
+    async def test_create_lmeval_cr_with_builtin_task(self, lmeval_instance):
+        """Test that builtin task names are correctly used as benchmark_id"""
+        builtin_tasks = ["mmlu", "hellaswag", "arc_easy", "arc_challenge", "truthfulqa"]
+
+        benchmark_config = BenchmarkConfig(
+            eval_candidate=ModelCandidate(
+                type="model",
+                model="test-model",
+                sampling_params=SamplingParams(max_tokens=100),
+            )
+        )
+
+        for task in builtin_tasks:
+            cr = lmeval_instance._create_lmeval_cr(task, benchmark_config)
+
+            assert cr["spec"]["taskList"]["taskNames"] == [task]
+            assert task.lower() in cr["metadata"]["name"]
+
+    @pytest.mark.asyncio
+    async def test_run_eval_with_builtin_task(self, lmeval_instance):
+        """Test that run_eval works with builtin task names"""
+        benchmark_config = BenchmarkConfig(
+            eval_candidate=ModelCandidate(
+                type="model",
+                model="test-model",
+                sampling_params=SamplingParams(max_tokens=100),
+            )
+        )
+
+        with patch.object(lmeval_instance, "_create_lmeval_cr") as mock_create_cr:
+            mock_create_cr.return_value = {"mock": "cr"}
+            job = await lmeval_instance.run_eval("mmlu", benchmark_config)
+            mock_create_cr.assert_called_once_with("mmlu", benchmark_config)
+            assert job.job_id is not None
+
+    @pytest.mark.asyncio
+    async def test_run_eval_with_custom_task(self, lmeval_instance):
+        """Test that run_eval works with custom task names"""
+        benchmark_config = BenchmarkConfig(
+            eval_candidate=ModelCandidate(
+                type="model",
+                model="test-model",
+                sampling_params=SamplingParams(max_tokens=100),
+            )
+        )
+
+        with patch.object(lmeval_instance, "_create_lmeval_cr") as mock_create_cr:
+            mock_create_cr.return_value = {"mock": "cr"}
+
+            job = await lmeval_instance.run_eval("custom_benchmark", benchmark_config)
+
+            mock_create_cr.assert_called_once_with("custom_benchmark", benchmark_config)
+
+            assert job.job_id is not None
+
+    @pytest.mark.asyncio
+    async def test_model_args_in_cr(self, lmeval_instance):
+        """Test that model args are correctly included in the CR"""
+        benchmark_config = BenchmarkConfig(
+            eval_candidate=ModelCandidate(
+                type="model",
+                model="openai/gpt-4",
+                sampling_params=SamplingParams(
+                    temperature=0.7,
+                    top_p=0.9,
+                    max_tokens=2048,
+                ),
+            )
+        )
+
+        cr = lmeval_instance._create_lmeval_cr("mmlu", benchmark_config)
+
+        model_args = cr["spec"]["modelArgs"]
+        model_name_arg = next((arg for arg in model_args if arg["name"] == "model"), None)
+        assert model_name_arg is not None
+        assert model_name_arg["value"] == "openai/gpt-4"


### PR DESCRIPTION
- Update LMEvalEvalProviderConfig to default and require use_k8s=True
- Add validation to prevent non-Kubernetes backends
- Add corresponding test cases for configuration validation

# What does this PR do?
[Provide a short summary of what this PR does and why. Link to relevant issues if applicable.]

[//]: # (If resolving an issue, uncomment and update the line below)
[//]: # (Closes #[issue-number])

## Test Plan
[Describe the tests you ran to verify your changes with result summaries. *Provide clear instructions so the plan can be easily re-executed.*]

[//]: # (## Documentation)
